### PR TITLE
Add mini NestJS+React soccer game skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# Codex test 입니다.
+# Mini Soccer Game
+
+This repository contains a simple example of a mini 5 vs 5 soccer game built with **NestJS** for the backend and **React** for the frontend using TypeScript.
+
+## Structure
+
+- `backend/` – NestJS project exposing a REST API for the game state.
+- `frontend/` – React app rendering the field and players.
+
+## Running locally (requires Node.js and Yarn or npm)
+
+```
+# Backend
+cd backend
+npm install
+npm run start
+
+# Frontend (in another terminal)
+cd ../frontend
+npm install
+npm run start
+```
+
+The frontend expects the backend to run on port `3001` and will fetch the game state from `/game`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "soccer-backend",
+  "version": "1.0.0",
+  "scripts": {
+    "start": "nest start"
+  },
+  "dependencies": {
+    "@nestjs/common": "^8.0.0",
+    "@nestjs/core": "^8.0.0",
+    "reflect-metadata": "^0.1.13",
+    "rxjs": "^7.0.0"
+  },
+  "devDependencies": {
+    "@nestjs/cli": "^8.0.0",
+    "typescript": "^4.0.0"
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { GameModule } from './game/game.module';
+
+@Module({
+  imports: [GameModule],
+})
+export class AppModule {}

--- a/backend/src/game/game.controller.ts
+++ b/backend/src/game/game.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { GameService } from './game.service';
+
+@Controller('game')
+export class GameController {
+  constructor(private readonly gameService: GameService) {}
+
+  @Get()
+  getState() {
+    return this.gameService.getState();
+  }
+
+  @Post('move')
+  moveBall(@Body() body: { x: number; y: number }) {
+    this.gameService.moveBall(body.x, body.y);
+    return this.gameService.getState();
+  }
+}

--- a/backend/src/game/game.module.ts
+++ b/backend/src/game/game.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { GameController } from './game.controller';
+import { GameService } from './game.service';
+
+@Module({
+  controllers: [GameController],
+  providers: [GameService],
+})
+export class GameModule {}

--- a/backend/src/game/game.service.ts
+++ b/backend/src/game/game.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+
+export interface Player {
+  id: number;
+  x: number;
+  y: number;
+  team: 'A' | 'B';
+}
+
+export interface GameState {
+  ball: { x: number; y: number };
+  players: Player[];
+  score: { A: number; B: number };
+}
+
+@Injectable()
+export class GameService {
+  private state: GameState = {
+    ball: { x: 50, y: 50 },
+    players: [],
+    score: { A: 0, B: 0 },
+  };
+
+  constructor() {
+    this.initPlayers();
+  }
+
+  private initPlayers() {
+    for (let i = 0; i < 5; i++) {
+      this.state.players.push({ id: i, x: 10, y: 20 * i + 10, team: 'A' });
+      this.state.players.push({ id: i + 5, x: 90, y: 20 * i + 10, team: 'B' });
+    }
+  }
+
+  getState(): GameState {
+    return this.state;
+  }
+
+  moveBall(x: number, y: number) {
+    this.state.ball = { x, y };
+  }
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,8 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+}
+bootstrap();

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "es2017",
+    "sourceMap": true,
+    "outDir": "dist",
+    "baseUrl": "./",
+    "incremental": true
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "soccer-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^17.0.0",
+    "react-dom": "^17.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.0.0",
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mini Soccer Game</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="/bundle.js"></script>
+</body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Game from './Game';
+
+export default function App() {
+  return (
+    <div>
+      <h1>Mini Soccer Game</h1>
+      <Game />
+    </div>
+  );
+}

--- a/frontend/src/Game.tsx
+++ b/frontend/src/Game.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface Player {
+  id: number;
+  x: number;
+  y: number;
+  team: 'A' | 'B';
+}
+
+interface GameState {
+  ball: { x: number; y: number };
+  players: Player[];
+  score: { A: number; B: number };
+}
+
+export default function Game() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [state, setState] = useState<GameState | null>(null);
+
+  useEffect(() => {
+    fetch('/game')
+      .then((res) => res.json())
+      .then(setState);
+  }, []);
+
+  useEffect(() => {
+    if (!canvasRef.current || !state) return;
+    const ctx = canvasRef.current.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, 100, 100);
+    ctx.fillStyle = 'green';
+    ctx.fillRect(0, 0, 100, 100);
+    ctx.fillStyle = 'white';
+    state.players.forEach((p) => {
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, 3, 0, Math.PI * 2);
+      ctx.fill();
+    });
+    ctx.fillStyle = 'red';
+    ctx.beginPath();
+    ctx.arc(state.ball.x, state.ball.y, 2, 0, Math.PI * 2);
+    ctx.fill();
+  }, [state]);
+
+  return (
+    <div>
+      <canvas ref={canvasRef} width={100} height={100} />
+      {state && (
+        <div>
+          Score A:{state.score.A} B:{state.score.B}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react"
+  },
+  "include": ["src"]
+}

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.tsx',
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  devServer: {
+    static: path.join(__dirname, 'public'),
+    port: 3000,
+  },
+};


### PR DESCRIPTION
## Summary
- initialize minimal NestJS backend with a game service and controller
- add React frontend with basic canvas rendering
- document how to run both apps in README

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_685080e479d4832ab484eeefed8d1b26